### PR TITLE
Implement better Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
 FROM quay.io/natlibfi/usemarcon:3
-ENTRYPOINT ["bin/yazproxy", "-c", "/conf/conf.xml", "@:8080"]
+ENTRYPOINT ["/yaz/entrypoint.sh"]
+
+ENV PORT 210
+ENV CONF /conf/conf.xml
 
 USER root
+
 COPY . /build/yazproxy
+COPY docker-entrypoint.sh /yaz/entrypoint.sh
+
 WORKDIR /build
 
 RUN apk -U --no-cache add libxslt libxml2 libgcrypt libgpg-error icu gnutls \
@@ -26,4 +32,3 @@ RUN apk -U --no-cache add libxslt libxml2 libgcrypt libgpg-error icu gnutls \
   && rm -rf /build tmp/* /var/cache/apk/*
 
 WORKDIR /yaz
-USER yaz

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+if [ $# -eq 0 ];then
+  exec bin/yazproxy -c $CONF @:$PORT -u yaz
+else
+  exec bin/yazproxy $@
+fi


### PR DESCRIPTION
- Run as root in Docker to support yazproxy's own internal user switch
- Support Docker CMD to pass in custom command line arguments
- Use port 210 by default