### PR TITLE
Implement better Docker support

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+if [ $# -eq 0 ];then
+  exec bin/yazproxy -c $CONF @:$PORT
+else
+  exec bin/yazproxy $@
+fi


### PR DESCRIPTION
- Fetches all dependencies from Index data's repositories (Our previous implementation used NatLibFi's Usemarcon base image. No more: Usemarcon sources are built and fetched from indexdata/usemarcon
- Allows defining dependency branch/tag/commit with Docker build args. Defaults to `master`
- Uses multi-stage builds
- Run as non-root.