### PR TITLE
Implement database validation

### DIFF
--- a/include/yazproxy/proxy.h
+++ b/include/yazproxy/proxy.h
@@ -131,6 +131,7 @@ class YAZ_EXPORT Yaz_Proxy : public yazpp_1::Z_Assoc {
     Z_APDU *handle_target_charset_conversion(Z_APDU *apdu);
 
     Z_APDU *handle_syntax_validation(Z_APDU *apdu);
+    Z_APDU *handle_database_validation(Z_APDU *apdu);
 
     void handle_charset_lang_negotiation(Z_APDU *apdu);
 

--- a/src/proxyp.h
+++ b/src/proxyp.h
@@ -148,6 +148,7 @@ public:
     char *get_explain_doc(ODR odr, const char *name, const char *db,
                           int *len, int *http_status);
     const char *get_explain_name(const char *db, const char **backend_db);
+    int check_is_defined_database(const char *name, const char *db);
  private:
     void operator=(const Yaz_ProxyConfig &conf);
     class Yaz_ProxyConfigP *m_cp;

--- a/src/yaz-proxy-config.cpp
+++ b/src/yaz-proxy-config.cpp
@@ -484,6 +484,30 @@ int Yaz_ProxyConfigP::check_type_1(ODR odr, xmlNodePtr ptr, Z_RPNQuery *query,
 }
 #endif
 
+int Yaz_ProxyConfig::check_is_defined_database(const char *name, const char *db) {
+#if YAZ_HAVE_XSLT
+    xmlNodePtr ptr;
+    struct _xmlAttr *attr;
+    
+    ptr = m_cp->find_target_node(name);
+        
+    if (ptr)
+    {    
+        for (attr = ptr->properties; attr; attr = attr->next)
+        {
+            if (attr->children && attr->children->type == XML_TEXT_NODE) {
+                if (!strcmp((const char *)attr->name, "database")
+                    && !strcmp((const char *)attr->children->content, db))
+                {
+                    return 1;
+                }
+            }                        
+        }
+    }
+#endif
+    return 0;
+}
+
 int Yaz_ProxyConfig::check_query(ODR odr, const char *name, Z_Query *query,
                                  char **addinfo)
 {


### PR DESCRIPTION
Leverages the unused `database` attribute (Which is present in the config schema) to constraint the proxy to use the specified database for the target. This is important for security reasons if there are multiple databases and access should only be allowed to specified databases. Also the [documentation](https://software.indexdata.com/yazproxy/doc/proxy-config-file.html#proxy-config-target) backs this up: `It is assumed that each URL represents the same database (data).`

Notes:
- Since the database attribute is not specified in documentation, I don't consider this a breaking change. However, if you are to accept this functionality, I can implement the functionality behind a command line flag etc.
- Works only for the default target. I don't really understand how multiple targets are supported by YAZ proxy. It seems that target node is fetched with proxy target host+port combination using the `name` attribute of the target but documentation doesn't talk about the format of that attribute.
