### PR TITLE
Include <stdlib.h> for atoi

### DIFF
--- a/src/yaz-proxy-config.cpp
+++ b/src/yaz-proxy-config.cpp
@@ -17,6 +17,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 #include <ctype.h>
+#include <stdlib.h>
 
 #include <yaz/log.h>
 #include "proxyp.h"


### PR DESCRIPTION
Fixes the bug reported [here](https://trac.macports.org/ticket/70063):

```
yaz-proxy-config.cpp: In member function ‘void Yaz_ProxyConfigP::get_period(xmlNode*, int*)’:
yaz-proxy-config.cpp:176: error: ‘atoi’ was not declared in this scope
yaz-proxy-config.cpp: In member function ‘void Yaz_ProxyConfigP::return_limit(xmlNode*, int*, int*, int*, int*)’:
yaz-proxy-config.cpp:195: error: ‘atoi’ was not declared in this scope
yaz-proxy-config.cpp:202: error: ‘atoi’ was not declared in this scope
yaz-proxy-config.cpp:209: error: ‘atoi’ was not declared in this scope
yaz-proxy-config.cpp:216: error: ‘atoi’ was not declared in this scope
yaz-proxy-config.cpp: In member function ‘void Yaz_ProxyConfigP::return_target_info(xmlNode*, const char**, int*, int*, int*, int*, int*, int*, int*, int*, int*, int*, const char**, const char**, const char**, const char**, const char**)’:
yaz-proxy-config.cpp:250: error: ‘atoi’ was not declared in this scope
yaz-proxy-config.cpp:281: error: ‘atoi’ was not declared in this scope
yaz-proxy-config.cpp:292: error: ‘atoi’ was not declared in this scope
yaz-proxy-config.cpp:303: error: ‘atoi’ was not declared in this scope
yaz-proxy-config.cpp: In member function ‘int Yaz_ProxyConfigP::check_type_1_attributes(odr*, xmlNode*, Z_AttributeList*, char**)’:
yaz-proxy-config.cpp:441: error: ‘atoi’ was not declared in this scope
yaz-proxy-config.cpp: In member function ‘int Yaz_ProxyConfig::check_syntax(odr*, const char*, Odr_oid*, Z_RecordComposition*, char**, char**, char**, char**, char**, char**, char**, char**)’:
yaz-proxy-config.cpp:911: error: ‘atoi’ was not declared in this scope
yaz-proxy-config.cpp: In member function ‘void Yaz_ProxyConfig::get_generic_info(int*, int*, int*, int*, int*, int*)’:
yaz-proxy-config.cpp:1100: error: ‘atoi’ was not declared in this scope
yaz-proxy-config.cpp:1114: error: ‘atoi’ was not declared in this scope
yaz-proxy-config.cpp:1124: error: ‘atoi’ was not declared in this scope
yaz-proxy-config.cpp:1132: error: ‘atoi’ was not declared in this scope
yaz-proxy-config.cpp:1141: error: ‘atoi’ was not declared in this scope
yaz-proxy-config.cpp:1162: error: ‘atoi’ was not declared in this scope
yaz-proxy-config.cpp: In member function ‘void Yaz_ProxyConfig::get_target_info(const char*, const char**, int*, int*, int*, int*, int*, int*, int*, int*, int*, int*, int*, const char**, const char**, const char**, const char**, const char**)’:
yaz-proxy-config.cpp:1353: error: ‘atoi’ was not declared in this scope
```

