### PR TITLE
Fix module.h include guard name

### DIFF
--- a/include/yazproxy/module.h
+++ b/include/yazproxy/module.h
@@ -17,7 +17,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 #ifndef YAZ_PROXY_MODULE_H
-#define YAZ_PROXY_MODULE_H_INCLUDED
+#define YAZ_PROXY_MODULE_H
 
 struct Yaz_ProxyModule_entry {
     int int_version;


### PR DESCRIPTION
This fixes the compiler warning:

```
./../include/yazproxy/module.h:19:9: warning: 'YAZ_PROXY_MODULE_H' is used as a header guard here, followed by #define of a different macro [-Wheader-guard]
#ifndef YAZ_PROXY_MODULE_H
        ^~~~~~~~~~~~~~~~~~
./../include/yazproxy/module.h:20:9: note: 'YAZ_PROXY_MODULE_H_INCLUDED' is defined here; did you mean 'YAZ_PROXY_MODULE_H'?
#define YAZ_PROXY_MODULE_H_INCLUDED
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
        YAZ_PROXY_MODULE_H
1 warning generated.
```